### PR TITLE
Add diagnostics ; evaluate row/column p-value separately

### DIFF
--- a/src/vetting/centroiding.py
+++ b/src/vetting/centroiding.py
@@ -27,6 +27,51 @@ def weighted_average(values, weights, axis=None):
     return mean, error / len(values) ** 0.5
 
 
+def plot_centroids_vs_time(lc, centroid_type, label=None):
+    # tmasks: list of transit mask, one for each planet candidate
+    tmasks = np.asarray([lc[f"tmask{i}"] for i in range(lc.meta["num_tmasks"])])
+    oot_mask = tmasks.all(axis=0)
+    with plt.style.context(lk.MPLSTYLE):
+        fig, axs = plt.subplots(
+            2,
+            1,
+            figsize=(8, 4 * 2),
+            sharex=True,
+        )
+
+    if centroid_type == "cent_diff":
+        col_plot_label_suffix = "centroid column diff"
+        row_plot_label_suffix = "centroid row diff"
+    elif centroid_type == "cent":
+        col_plot_label_suffix = "centroid column"
+        row_plot_label_suffix = "centroid row"
+    elif centroid_type == "tr":
+        col_plot_label_suffix = "centroid detrended"
+        row_plot_label_suffix = "centroid detrended"
+    else:
+        raise ValueError(f"Unsupported centroid type: {centroid_type}")
+
+    ax = lc[oot_mask].scatter(ax=axs[0], column=f"x{centroid_type}", alpha=0.3, label=f"OOT {col_plot_label_suffix}")
+    for idx in range(len(tmasks)):
+        # Transits of planet IDX
+        it_mask = ~tmasks[idx]
+        lc[it_mask].scatter(ax=ax, column=f"x{centroid_type}", s=16, marker="*", label=f"Pl {idx + 1} {col_plot_label_suffix}")
+
+    ax = lc[oot_mask].scatter(ax=axs[1], column=f"y{centroid_type}", alpha=0.3, label=f"OOT {row_plot_label_suffix}")
+    for idx in range(len(tmasks)):
+        # Transits of planet IDX
+        it_mask = ~tmasks[idx]
+        lc[it_mask].scatter(ax=ax, column=f"y{centroid_type}", s=16, marker="*", label=f"Pl {idx + 1} {row_plot_label_suffix}")
+
+    plt.subplots_adjust(hspace=0)
+
+    if label is None:
+        label = lc.meta.get("LABEL")
+    if label is not None:
+        fig.suptitle(label)
+    return fig
+
+
 def centroid_test(
     tpfs,
     periods,
@@ -35,6 +80,7 @@ def centroid_test(
     kernel=21,
     aperture_mask="pipeline",
     plot=True,
+    include_diagnostics=False,
     nsamp=100,
     transit_depths=None,
     labels=None,
@@ -122,6 +168,9 @@ def centroid_test(
     if transit_depths is not None:
         for key in ["1sigma_error"]:
             r[key] = []
+    if include_diagnostics:
+        for key in ["lc_list", "tpf_m_list", "diagnostics_figs"]:
+            r[key] = []
 
     for tpf in tpfs:
         if tpf.mission.lower() in ["kepler", "ktwo", "k2"]:
@@ -146,6 +195,9 @@ def centroid_test(
         mask &= np.nan_to_num(tpf.to_lightcurve(aperture_mask=aper).flux) != 0
         tpf = tpf[mask]
         lc = tpf.to_lightcurve(aperture_mask=aper)
+        if include_diagnostics:
+            r["tpf_m_list"].append(tpf)
+            r["lc_list"].append(lc)
 
         tmasks = []
         for period, t0, duration in zip(periods, t0s, durs):
@@ -155,6 +207,14 @@ def centroid_test(
             )
             tmasks.append(t_mask)
         tmasks = np.asarray(tmasks)
+        if include_diagnostics:
+            # put tmasks as a list of extra columns, one for each planet
+            # this is done (instead of, say, putting the entire `tmasks`` in meta)
+            # to make it easy for users to truncate the lc and plot only a section of the time range
+            # (the tmasks would be truncated accordingly, by the virtue that they are basic columns)
+            for i in range(len(tmasks)):
+                lc[f"tmask{i}"] = tmasks[i]
+            lc.meta["num_tmasks"] = len(tmasks)
         Y, X = np.mgrid[: tpf.shape[1], : tpf.shape[2]]
         X = (X[aper][:, None] * np.ones(tpf.shape[0])).T
         Y = (Y[aper][:, None] * np.ones(tpf.shape[0])).T
@@ -235,6 +295,22 @@ def centroid_test(
         ysamps = np.random.normal(
             ycent[:, 0] - ytr, ycent[:, 1], size=(nsamp, len(ycent))
         )
+
+        if include_diagnostics:
+            lc["xcent"] = xcent[:, 0]
+            lc["xcent_err"] = xcent[:, 1]
+            lc["ycent"] = ycent[:, 0]
+            lc["ycent_err"] = ycent[:, 1]
+            lc["xtr"] = xtr
+            lc["ytr"] = ytr
+            lc["xcent_diff"] = lc["xcent"] - lc["xtr"]
+            lc["ycent_diff"] = lc["ycent"] - lc["ytr"]
+            lc.meta["xsamps"] = xsamps
+            lc.meta["ysamps"] = ysamps
+
+        if include_diagnostics and plot:
+            diagnostics_fig = plot_centroids_vs_time(lc, "cent_diff", label=_label(tpf))
+            r["diagnostics_figs"].append(diagnostics_fig)
 
         if plot:
             with plt.style.context("seaborn-white"):


### PR DESCRIPTION
They are two loosely related issues.
1. Support diagnostics by providing ways to access the estimated centroids, smoothed centroids, etc. with new `include_diagnostics` parameter in `centroid_test()` function.

2. The `p-value` currently used for centroid shift detection is a mean of p-values of the X and Y centroids. That seems to be problematic. 
 
E.g., for TIC 13023738, sector 2 referenced in the [associated paper](https://iopscience.iop.org/article/10.3847/2515-5172/ac376a), `centroid_test()` reports no centroid shift detected because the mean `p-value` is large (~0.25). But in reality, there is clear centroid shift in X (tiny `p-value` ~6e-7). In the test, it is overshadowed / averaged out by the large `p-value` in Y (~0.50).

To handle such cases, the second commit of this PR changes the detection from using a mean of X / Y `p-value`s, to using the minimum of X and Y `p-value`s.

---

E.g., for TIC 13023738, sector 2 referenced in the [associated paper](https://iopscience.iop.org/article/10.3847/2515-5172/ac376a), the diagnostics could help to pinpoint the X / column centroids have a noticeable shift:

![image](https://user-images.githubusercontent.com/250644/169872561-e2130443-e359-4ae6-be88-a1b6b7e773e5.png)

Another use is to manually inspect whether the smoothing is over/under aggressive.

--- 

Note: If the PR is to be accepted, some polish probably needs to be done (e.g., documentation, consistent labeling of the planet candidate, deciding what `p-value`(s) to report, etc.). I'm holding off pending feedback.